### PR TITLE
Remove trailing dots from URLs in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ except ImportError:
 setup(
     description='Wharfee: a shell for Docker',
     author='Iryna Cherniavska',
-    url='http://wharfee.com.',
-    download_url='http://github.com/j-bennet/wharfee.',
-    author_email='i[dot]chernyavska[at]gmail[dot]com.',
+    url='http://wharfee.com',
+    download_url='http://github.com/j-bennet/wharfee',
+    author_email='i[dot]chernyavska[at]gmail[dot]com',
     version=__version__,
     install_requires=[
         'six>=1.9.0',


### PR DESCRIPTION
The trailing dots in the URLs render them useless when they have been picked up by services like pypi. These services will include the trailing dot in the link. These links will point to inexistent locations then.