### PR TITLE
Crash at processing explanation from APIError.

### DIFF
--- a/wharfee/client.py
+++ b/wharfee/client.py
@@ -192,7 +192,7 @@ class DockerClient(object):
 
                 except APIError as ex:
                     reset_output()
-                    self.output = [ex.explanation]
+                    self.output = [str(ex.explanation)]
 
                 except OptionError as ex:
                     reset_output()


### PR DESCRIPTION
Trying to pull an unknown repo triggers an APIError from docker-py. The explanation text is not correctly interpreted by docker-py (this is already fixed in the current master of docker-py/errors.py, but not yet released).
Anyway, the explanation text is made with bytes, which provoke a crash:

> $ wharfee
> Version: 0.10
> Home: http://wharfee.com
> wharfee> pull mo
> sequence item 0: expected str instance, bytes found
> Goodbye!
> $
 
Turning the explanation into str, avoid the crash and should prepare the next release of docker-py.
