### PR TITLE
Handle volumes mapping with spaces

### DIFF
--- a/wharfee/options.py
+++ b/wharfee/options.py
@@ -768,6 +768,8 @@ def format_command_line(cmd, is_long, args, kwargs):
     def kv(o, v):
         if o.dest == 'environment':
             return kve(o, v)
+        elif o.dest == 'volumes' and ' ' in v:
+            return '{0}="{1}"'.format(o.get_name(is_long), v)
         return '{0}={1}'.format(o.get_name(is_long), v)
 
     for opt_dest, opt_value in kwargs.items():


### PR DESCRIPTION
When the volumes mapping contain a space, the command is not protected:
> wharfee> run -v '/Users/foo/Google Drive:/var/gdrive' alpine:edge ls /var/gdrive
> /usr/local/bin/docker: Error parsing reference: "Drive:/var/gdrive" is not a valid repository/tag:  invalid reference format.
> See '/usr/local/bin/docker run --help'.
> Interactive terminal is closed.