### PR TITLE
Update for docker-py 2.x.x. 

### DIFF
--- a/tests/features/docker_utils.py
+++ b/tests/features/docker_utils.py
@@ -28,10 +28,10 @@ def init_docker_client(timeout=2):
         if 'tls' in kwargs:
             kwargs['tls'].assert_hostname = False
         kwargs['timeout'] = timeout
-        client = DockerClientAPI(**kwargs)
+        client = DockerAPIClient(**kwargs)
     else:
         # unix-based
-        client = DockerClientAPI(
+        client = DockerAPIClient(
             timeout=timeout,
             base_url='unix://var/run/docker.sock')
     return client

--- a/tests/features/docker_utils.py
+++ b/tests/features/docker_utils.py
@@ -8,7 +8,12 @@ Helpers to connect to docker.
 
 import sys
 
-from docker import AutoVersionClient
+# make sure docker-py client API class according to docker-py version
+from docker import version_info as docker_version_info
+if docker_version_info >= (2, 0, 0):
+    from docker.api import APIClient as DockerAPIClient
+else:
+    from docker import AutoVersionClient as DockerAPIClient
 from docker.utils import kwargs_from_env
 
 
@@ -23,10 +28,10 @@ def init_docker_client(timeout=2):
         if 'tls' in kwargs:
             kwargs['tls'].assert_hostname = False
         kwargs['timeout'] = timeout
-        client = AutoVersionClient(**kwargs)
+        client = DockerClientAPI(**kwargs)
     else:
         # unix-based
-        client = AutoVersionClient(
+        client = DockerClientAPI(
             timeout=timeout,
             base_url='unix://var/run/docker.sock')
     return client

--- a/wharfee/client.py
+++ b/wharfee/client.py
@@ -128,7 +128,7 @@ class DockerClient(object):
                 if 'tls' in kwargs:
                     kwargs['tls'].assert_hostname = False
                 kwargs['timeout'] = timeout
-                self.instance = AutoVersionClient(**kwargs)
+                self.instance = DockerAPIClient(**kwargs)
 
             except DockerException as x:
                 if 'CERTIFICATE_VERIFY_FAILED' in str(x):

--- a/wharfee/client.py
+++ b/wharfee/client.py
@@ -10,7 +10,12 @@ import pexpect
 import ssl
 import six
 
-from docker import AutoVersionClient
+# make sure docker-py client API class according to docker-py version
+from docker import version_info as docker_version_info
+if docker_version_info >= (2, 0, 0):
+    from docker.api import APIClient as DockerAPIClient
+else:
+    from docker import AutoVersionClient as DockerAPIClient
 from docker.utils import kwargs_from_env
 from docker.errors import APIError
 from docker.errors import DockerException, InvalidVersion
@@ -138,7 +143,7 @@ class DockerClient(object):
                 ssl_version=ssl.PROTOCOL_TLSv1,
                 assert_hostname=False)
             kwargs['timeout'] = timeout
-            self.instance = AutoVersionClient(**kwargs)
+            self.instance = DockerAPIClient(**kwargs)
 
     def debug(self, message):
         """Log a debug message if logger is passed in."""


### PR DESCRIPTION
Support docker-py 2.x.x. AutoVersionClient method is no longer available in docker-py 2.x.x. This modification calls the right API to get docker client according to docker-py version.