### PR TITLE
[WIP] Use yaml to format hierarchical info.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - docker --version
 
 install:
-  - pip install pip==9.0
+  - pip install pip==9.0.1
   - pip install -r requirements-dev.txt
   - pip install codecov
   - pip install -e .

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,7 +1,7 @@
 Upcoming
 ========
 
-* Use pyyaml to format hierarchical info.
+* Use ``ruamel.yaml`` to format hierarchical info.
 
 0.10
 ====

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,3 +1,8 @@
+Upcoming
+========
+
+* Use pyyaml to format hierarchical info.
+
 0.10
 ====
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
         'py-pretty>=0.1',
         'configobj>=5.0.6',
         'pexpect>=3.3',
-        'fuzzyfinder>=1.0.0'
+        'fuzzyfinder>=1.0.0',
+        'PyYAML>=3.13'
     ],
     extras_require={
         'testing': [

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'configobj>=5.0.6',
         'pexpect>=3.3',
         'fuzzyfinder>=1.0.0',
-        'PyYAML>=3.13'
+        'ruamel.yaml>=0.15.72',
     ],
     extras_require={
         'testing': [

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -128,7 +128,7 @@ def test_dict_data_formatting():
         }
     }
 
-    lines = format_struct(data, spaces=2)
+    lines = format_struct(data, indent=2)
 
     print('\n')
     for line in lines:
@@ -183,7 +183,7 @@ def test_info_data_formatting():
         'SystemTime': '2015-04-29T04:58:07.548655766Z'
     }
 
-    lines = format_struct(data, spaces=2)
+    lines = format_struct(data, indent=2)
 
     print('\n')
     for line in lines:

--- a/wharfee/client.py
+++ b/wharfee/client.py
@@ -258,8 +258,7 @@ class DockerClient(object):
 
         try:
             verdict = self.instance.version()
-            result = [(k, verdict[k]) for k in sorted(verdict.keys())]
-            return result
+            return verdict
         except ConnectionError as ex:
             raise DockerPermissionException(ex)
 
@@ -268,10 +267,8 @@ class DockerClient(object):
         Return the system info. Equivalent of docker info.
         :return: list of tuples
         """
-
-        rdict = self.instance.info()
-        result = [(k, rdict[k]) for k in sorted(rdict.keys())]
-        return result
+        info_dict = self.instance.info()
+        return info_dict
 
     def inspect(self, *args, **_):
         """

--- a/wharfee/formatter.py
+++ b/wharfee/formatter.py
@@ -12,7 +12,12 @@ from tabulate import tabulate
 from pygments import highlight
 from pygments.lexers.data import JsonLexer
 from pygments.formatters.terminal import TerminalFormatter
-from yaml import dump
+from ruamel.yaml import YAML
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 # Python 3 has no 'basestring' or 'long' type we're checking for.
 try:
@@ -212,8 +217,12 @@ def format_data(command, data):
 
 
 def format_struct(data, indent=4):
-    text = dump(data, indent=indent, default_flow_style=False)
-    lines = text.split('\n')
+    output = StringIO()
+    yaml = YAML()
+    yaml.default_flow_style = False
+    yaml.indent = indent
+    yaml.dump(data, stream=output)
+    lines = output.getvalue().split('\n')
     return lines
 
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

Get rid of custom formatting in `info` and `version` and use yaml dumper instead.

## Checklist
<!--- Please take a moment to update the changelog with your contribution. Thank you! -->
- [x] I've added this contribution to the `changelog.rst`.
