### PR TITLE
Issue 147 resolved

### DIFF
--- a/wharfee/client.py
+++ b/wharfee/client.py
@@ -1215,7 +1215,9 @@ class DockerClient(object):
             # prompt is back to beginning of line
             self.is_refresh_containers = True
             self.is_refresh_running = True
-            return ['\rInteractive terminal is closed.']
+            if is_interactive or is_tty:
+                return ['\rInteractive terminal is closed.']
+            return []
 
         def on_after_attach():
             self.is_refresh_containers = True

--- a/wharfee/main.py
+++ b/wharfee/main.py
@@ -339,6 +339,9 @@ class WharfeeCli(object):
                 self.logger.error("traceback: %r", traceback.format_exc())
                 click.secho(str(ex), fg='red')
 
+        if '-i' in sys.argv or '-t' in sys.argv:
+            print('Interactive terminal is closed.')
+
         self.revert_less_opts()
         self.write_config_file()
         print('Goodbye!')

--- a/wharfee/options.py
+++ b/wharfee/options.py
@@ -743,6 +743,10 @@ def parse_command_options(cmd, params):
             if opt.default is not None:
                 popts[opt.dest] = opt.default
 
+    # Check for interactive terminal options
+    if '-i' in params or '-t' in params:
+        print("Interactive terminal is closed.")
+
     return parser, popts, pargs
 
 


### PR DESCRIPTION
To solve the problem, we need to add a condition to check if the terminal is interactive before printing the message 'Interactive terminal is closed.'. This can be done by checking the presence of the '-i' or '-t' switches or any other relevant condition that determines interactivity.
To solve the problem, we need to modify the `on_after_interactive` function to check if the terminal was interactive before returning the message 'Interactive terminal is closed.'. Specifically, we need to add a condition to check if `is_interactive` or `is_tty` is True before setting the message.
To solve the problem, we need to add a conditional check to verify if the '-i' or '-t' switch is present in the options before printing the 'Interactive terminal is closed.' message.